### PR TITLE
Add support for guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "~7.0",
-    "adelowo/gbowo": "^1.4"
+    "adelowo/gbowo": "^1.4|master"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",
@@ -29,5 +29,11 @@
       "Paystack\\Tests\\" : "tests/Paystack/"
     }
   },
-  "keywords" : ["gbowo", "paystack"]
+ "keywords" : ["gbowo", "paystack"],
+ "repositories": [
+    {
+      "type": "vcs",
+      "url" : "https://github.com/xavi7th/gbowo"
+    }
+  ],
 }


### PR DESCRIPTION
Add xavi7th branch that adds support for guzzle 7 to repositories for "adelowo/gbowo": "^1.4|master"